### PR TITLE
Only add to chpwd_functions if not already in there

### DIFF
--- a/auto-ls.zsh
+++ b/auto-ls.zsh
@@ -29,4 +29,7 @@ auto-ls () {
 
 zle -N auto-ls
 zle -N accept-line auto-ls
-chpwd_functions+=(auto-ls)
+
+if [[ ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
+  chpwd_functions+=(auto-ls)
+fi


### PR DESCRIPTION
This is especially useful if you do any kind of updates and with this process the auto-ls.zsh file gets sourced again.

In previous cases you would get two complete ls outputs per directory change. This is fixed with this little check.