### PR TITLE
Did not work if chpwd_functions was empty before

### DIFF
--- a/auto-ls.zsh
+++ b/auto-ls.zsh
@@ -30,6 +30,6 @@ auto-ls () {
 zle -N auto-ls
 zle -N accept-line auto-ls
 
-if [[ ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
+if [[ $chpwd_functions != "" && ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
   chpwd_functions+=(auto-ls)
 fi

--- a/auto-ls.zsh
+++ b/auto-ls.zsh
@@ -30,6 +30,6 @@ auto-ls () {
 zle -N auto-ls
 zle -N accept-line auto-ls
 
-if [[ $chpwd_functions == "" || ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
+if [[ ${chpwd_functions[(I)auto-ls]} -eq 0 ]]; then
   chpwd_functions+=(auto-ls)
 fi

--- a/auto-ls.zsh
+++ b/auto-ls.zsh
@@ -30,6 +30,6 @@ auto-ls () {
 zle -N auto-ls
 zle -N accept-line auto-ls
 
-if [[ $chpwd_functions != "" && ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
+if [[ $chpwd_functions == "" || ${chpwd_functions[(i)auto-ls]} -gt ${#chpwd_functions} ]]; then
   chpwd_functions+=(auto-ls)
 fi


### PR DESCRIPTION
I just added a check if chpwd_functions is empty, because in that case auto-ls would not be added and therefore not work.