### PR TITLE
Rework ZLE interaction

### DIFF
--- a/auto-ls.zsh
+++ b/auto-ls.zsh
@@ -16,8 +16,14 @@ auto-ls-git-status () {
 }
 
 auto-ls () {
-  if [[ $#BUFFER -eq 0 ]]; then
-    zle && echo ""
+  # Possible invocation sources:
+  #  1. Called from `chpwd_functions` – show file list
+  #  2. Called by another ZLE plugin (like `dirhistory`) through `zle accept-line` – show file list
+  #  3. Called by ZLE itself – only should file list if prompt was empty
+  if ! zle                          \
+  || { [[ ${WIDGET} != accept-line ]] && [[ ${LASTWIDGET} != .accept-line ]] }\
+  || { [[ ${WIDGET} == accept-line ]] && [[ $#BUFFER -eq 0 ]] }; then
+    zle && echo
     for cmd in $AUTO_LS_COMMANDS; do
       # If we detect a command with full path, ex: /bin/ls execute it
       if [[ $AUTO_LS_PATH != false && $cmd =~ '/' ]]; then
@@ -27,9 +33,21 @@ auto-ls () {
         auto-ls-$cmd
       fi
     done
-    zle && zle redisplay
-  else
-    zle .$WIDGET
+  fi
+
+  # Forward this event down the ZLE stack
+  if zle; then
+    if [[ ${WIDGET} == accept-line ]] && [[ $#BUFFER -eq 0 ]]; then
+      # Shortcut to reduce the number of empty lines appearing
+      # when pressing Enter
+      echo && zle redisplay
+    elif [[ ${WIDGET} != accept-line ]] && [[ ${LASTWIDGET} == .accept-line ]]; then
+      # Hack to make only 2 lines appear after `dirlist` navigation
+      # (Uses a VT100 escape sequence to move curser up one line…)
+      tput cuu 1
+    else
+      zle .accept-line
+    fi
   fi
 }
 


### PR DESCRIPTION
Fixes the missing last line seen when running `ls` after empty prompt (#6).

Fixes the complex interaction with other plugins using `zle accept-line` (like `dirhistory`).

Ensures that there is always exactly one newline added when called from empty prompt; two new lines when called from `cd` or `dirhistory`.